### PR TITLE
Enable subscribe button klaviyo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG
 
-## [1.6.1]
+## [1.7.0]
 
 ### Changed
 
- - countable.rb now returns zero if there is a 400 error
+ - Updated to return count as zero, when there are no results found in klaviyo account
   
 ## [1.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [1.6.1]
+
+### Changed
+
+ - countable.rb now returns zero if there is a 400 error
+  
 ## [1.6.0]
 
 ### Added

--- a/lib/klaviyo_api/resources/support/countable.rb
+++ b/lib/klaviyo_api/resources/support/countable.rb
@@ -5,6 +5,11 @@ module KlaviyoAPI::Support
     def count(params = {})
       all_params = params.deep_merge(params: { count: 1 })
       all(all_params).total
+    # klaviyo returns 400 if there are no people/profile in the account, so we catch it and display zero as the total subscribers
+    rescue => e
+      Nucleus::Logger.warn 'Received a 400 error, returning zero', error: e
+
+      0
     end
   end
 end

--- a/lib/klaviyo_api/resources/support/countable.rb
+++ b/lib/klaviyo_api/resources/support/countable.rb
@@ -6,7 +6,7 @@ module KlaviyoAPI::Support
       all_params = params.deep_merge(params: { count: 1 })
       all(all_params).total
     # klaviyo returns 400 if there are no people/profile in the account, so we catch it and display zero as the total subscribers
-    rescue => e
+    rescue ActiveResource::BadRequest => e
       Nucleus::Logger.warn 'Received a 400 error, returning zero', error: e
 
       0

--- a/lib/klaviyo_api/resources/support/countable.rb
+++ b/lib/klaviyo_api/resources/support/countable.rb
@@ -7,8 +7,6 @@ module KlaviyoAPI::Support
       all(all_params).total
     # klaviyo returns 400 if there are no results found in the account, so we catch it and return zero
     rescue ActiveResource::BadRequest => e
-      Nucleus::Logger.warn 'Received a 400 error, returning zero', error: e
-
       0
     end
   end

--- a/lib/klaviyo_api/resources/support/countable.rb
+++ b/lib/klaviyo_api/resources/support/countable.rb
@@ -5,7 +5,7 @@ module KlaviyoAPI::Support
     def count(params = {})
       all_params = params.deep_merge(params: { count: 1 })
       all(all_params).total
-    # klaviyo returns 400 if there are no people/profile in the account, so we catch it and display zero as the total subscribers
+    # klaviyo returns 400 if there are no results found in the account, so we catch it and return zero
     rescue ActiveResource::BadRequest => e
       Nucleus::Logger.warn 'Received a 400 error, returning zero', error: e
 

--- a/lib/klaviyo_api/version.rb
+++ b/lib/klaviyo_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KlaviyoAPI
-  VERSION = '1.6.1'
+  VERSION = '1.7.0'
 end

--- a/lib/klaviyo_api/version.rb
+++ b/lib/klaviyo_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KlaviyoAPI
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end

--- a/test/resources/support/test_countable.rb
+++ b/test/resources/support/test_countable.rb
@@ -3,12 +3,13 @@
 require 'test_helper'
 
 describe KlaviyoAPI::Support::Countable do
-  before do
-    stub_request(:get, "https://a.klaviyo.com/api/v1/people?api_key=&count=1")
-      .to_return body: load_fixture(:paginated_collection)
+  it 'successfully gets a count' do
+    stub_request(:get, 'https://a.klaviyo.com/api/v1/people?api_key=&count=1').to_return body: load_fixture(:paginated_collection)
+    assert_equal 567, KlaviyoAPI::Profile.count
   end
 
-  it 'successfully gets a count' do
-    assert_equal 567, KlaviyoAPI::Profile.count
+  it 'returns zero when 400 error is returned from klaviyo' do
+    stub_request(:get, 'https://a.klaviyo.com/api/v1/people?api_key=&count=1').to_return(status: 400, body: '')
+    assert_equal 0, KlaviyoAPI::Profile.count
   end
 end


### PR DESCRIPTION
Klaviyo returns a 400 in case there are no results found on the account. These changes will add a fix to catch the 400 error and return the count as zero.